### PR TITLE
ロールに通報の制限を行うための設定を追加

### DIFF
--- a/locales/index.d.ts
+++ b/locales/index.d.ts
@@ -5174,6 +5174,14 @@ export interface Locale extends ILocale {
      * サブスクリプションの状態
      */
     "subscriptionStatus": string;
+    /**
+     * 通報不可
+     */
+    "abuseAbortTitle": string;
+    /**
+     * ロールにより通報が制限されているため、通報を行うことができません。
+     */
+    "abuseAbortText": string;
     "_subscription": {
         /**
          * 現在のプラン
@@ -7033,6 +7041,10 @@ export interface Locale extends ILocale {
              * セクション内の相互リンクの最大数
              */
             "mutualLinkLimit": string;
+            /**
+             * 通報の許可
+             */
+            "allowReport": string;
         };
         "_condition": {
             /**

--- a/locales/ja-JP.yml
+++ b/locales/ja-JP.yml
@@ -1288,6 +1288,8 @@ mutualLink: "相互リンク"
 saveThisFile: "このファイルをドライブに保存する"
 subscription: "サブスクリプション"
 subscriptionStatus: "サブスクリプションの状態"
+abuseAbortTitle: "通報不可"
+abuseAbortText: "ロールにより通報が制限されているため、通報を行うことができません。"
 
 _subscription:
   current: "現在のプラン"
@@ -1814,6 +1816,7 @@ _role:
     avatarDecorationLimit: "アイコンデコレーションの最大取付個数"
     mutualLinkSectionLimit: "相互リンクのセクションの最大数"
     mutualLinkLimit: "セクション内の相互リンクの最大数"
+    allowReport: "通報の許可"
   _condition:
     roleAssignedTo: "マニュアルロールにアサイン済み"
     isLocal: "ローカルユーザー"

--- a/packages/backend/src/core/RoleService.ts
+++ b/packages/backend/src/core/RoleService.ts
@@ -72,6 +72,7 @@ export type RolePolicies = {
 	avatarDecorationLimit: number;
 	mutualLinkSectionLimit: number;
 	mutualLinkLimit: number;
+	allowReport: boolean;
 };
 
 export const DEFAULT_POLICIES: RolePolicies = {
@@ -114,6 +115,7 @@ export const DEFAULT_POLICIES: RolePolicies = {
 	avatarDecorationLimit: 1,
 	mutualLinkSectionLimit: 1,
 	mutualLinkLimit: 3,
+	allowReport: true,
 };
 
 @Injectable()
@@ -429,6 +431,7 @@ export class RoleService implements OnApplicationShutdown, OnModuleInit {
 			avatarDecorationLimit: calc('avatarDecorationLimit', vs => Math.max(...vs)),
 			mutualLinkSectionLimit: calc('mutualLinkSectionLimit', vs => Math.max(...vs)),
 			mutualLinkLimit: calc('mutualLinkLimit', vs => Math.max(...vs)),
+			allowReport: calc('allowReport', vs => vs.some(v => v === true)),
 		};
 	}
 

--- a/packages/backend/src/models/json-schema/role.ts
+++ b/packages/backend/src/models/json-schema/role.ts
@@ -320,6 +320,10 @@ export const packedRolePoliciesSchema = {
 			type: 'integer',
 			optional: false, nullable: false,
 		},
+		allowReport: {
+			type: 'boolean',
+			optional: false, nullable: false,
+		},
 	},
 } as const;
 

--- a/packages/backend/src/server/api/endpoints/users/report-abuse.ts
+++ b/packages/backend/src/server/api/endpoints/users/report-abuse.ts
@@ -19,6 +19,7 @@ export const meta = {
 	tags: ['users'],
 
 	requireCredential: true,
+	requireRolePolicy: 'allowReport',
 	kind: 'write:report-abuse',
 
 	description: 'File a report.',

--- a/packages/frontend/src/const.ts
+++ b/packages/frontend/src/const.ts
@@ -111,6 +111,7 @@ export const ROLE_POLICIES = [
 	'avatarDecorationLimit',
 	'mutualLinkSectionLimit',
 	'mutualLinkLimit',
+	'allowReport',
 ] as const;
 
 // なんか動かない

--- a/packages/frontend/src/pages/admin/roles.editor.vue
+++ b/packages/frontend/src/pages/admin/roles.editor.vue
@@ -851,6 +851,26 @@ SPDX-License-Identifier: AGPL-3.0-only
 					</MkRange>
 				</div>
 			</MkFolder>
+
+			<MkFolder v-if="matchQuery([i18n.ts._role._options.allowReport, 'allowReport'])">
+				<template #label>{{ i18n.ts._role._options.allowReport }}</template>
+				<template #suffix>
+					<span v-if="role.policies.allowReport.useDefault" :class="$style.useDefaultLabel">{{ i18n.ts._role.useBaseValue }}</span>
+					<span v-else>{{ role.policies.allowReport.value ? i18n.ts.yes : i18n.ts.no }}</span>
+					<span :class="$style.priorityIndicator"><i :class="getPriorityIcon(role.policies.allowReport)"></i></span>
+				</template>
+				<div class="_gaps">
+					<MkSwitch v-model="role.policies.allowReport.useDefault" :readonly="readonly">
+						<template #label>{{ i18n.ts._role.useBaseValue }}</template>
+					</MkSwitch>
+					<MkSwitch v-model="role.policies.allowReport.value" :disabled="role.policies.allowReport.useDefault" :readonly="readonly">
+						<template #label>{{ i18n.ts.enable }}</template>
+					</MkSwitch>
+					<MkRange v-model="role.policies.allowReport.priority" :min="0" :max="2" :step="1" easing :textConverter="(v) => v === 0 ? i18n.ts._role._priority.low : v === 1 ? i18n.ts._role._priority.middle : v === 2 ? i18n.ts._role._priority.high : ''">
+						<template #label>{{ i18n.ts._role.priority }}</template>
+					</MkRange>
+				</div>
+			</MkFolder>
 		</div>
 	</FormSlot>
 </div>

--- a/packages/frontend/src/pages/admin/roles.vue
+++ b/packages/frontend/src/pages/admin/roles.vue
@@ -314,6 +314,14 @@ SPDX-License-Identifier: AGPL-3.0-only
 							</MkInput>
 						</MkFolder>
 
+						<MkFolder v-if="matchQuery([i18n.ts._role._options.allowReport, 'allowReport'])">
+							<template #label>{{ i18n.ts._role._options.allowReport }}</template>
+							<template #suffix>{{ policies.allowReport ? i18n.ts.yes : i18n.ts.no }}</template>
+							<MkSwitch v-model="policies.allowReport">
+								<template #label>{{ i18n.ts.enable }}</template>
+							</MkSwitch>
+						</MkFolder>
+
 						<MkButton primary rounded @click="updateBaseRole">{{ i18n.ts.save }}</MkButton>
 					</div>
 				</MkFolder>

--- a/packages/frontend/src/scripts/get-note-menu.ts
+++ b/packages/frontend/src/scripts/get-note-menu.ts
@@ -132,6 +132,16 @@ export function getAbuseNoteMenu(note: Misskey.entities.Note, text: string): Men
 		icon: 'ti ti-exclamation-circle',
 		text,
 		action: (): void => {
+			if (!$i?.policies.allowReport) {
+				os.alert({
+					type: 'error',
+					title: i18n.ts.abuseAbortTitle,
+					text: i18n.ts.abuseAbortText,
+				});
+
+				return;
+			}
+
 			const localUrl = `${url}/notes/${note.id}`;
 			let noteInfo = '';
 			if (note.url ?? note.uri != null) noteInfo = `Note: ${note.url ?? note.uri}\n`;

--- a/packages/frontend/src/scripts/get-user-menu.ts
+++ b/packages/frontend/src/scripts/get-user-menu.ts
@@ -100,6 +100,16 @@ export function getUserMenu(user: Misskey.entities.UserDetailed, router: IRouter
 	}
 
 	function reportAbuse() {
+		if (!$i?.policies.allowReport) {
+			os.alert({
+				type: 'error',
+				title: i18n.ts.abuseAbortTitle,
+				text: i18n.ts.abuseAbortText,
+			});
+
+			return;
+		}
+
 		os.popup(defineAsyncComponent(() => import('@/components/MkAbuseReportWindow.vue')), {
 			user: user,
 		}, {}, 'closed');


### PR DESCRIPTION
## What
ロールポリシーにallowReportを追加し、通報UIとエンドポイントの呼び出しに対しポリシーによる制御を実装。

## Why
無効通報を連続して送信するユーザーに対し、サーバー管理者が通報を制限する手段を提供したいため。

## Checklist
- [x] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
