### PR TITLE
fix(subscription): Stripeに顧客を新規作成する前にAPIに存在確認をするようにした

### DIFF
--- a/packages/backend/src/server/api/endpoints/subscription/create.ts
+++ b/packages/backend/src/server/api/endpoints/subscription/create.ts
@@ -118,6 +118,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 				const makeCustomer = await stripe.customers.create({
 					email: userProfile.email,
+				}, {
+					idempotencyKey: user.id,
 				});
 				await this.userProfilesRepository.update({ userId: user.id }, {
 					stripeCustomerId: makeCustomer.id,
@@ -167,7 +169,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 						return;
 					}
 
-					await stripe.subscriptionItems.update(subscriptionItem.id, { plan: plan.stripePriceId });
+					await stripe.subscriptionItems.update(subscriptionItem.id, { plan: plan.stripePriceId }, { idempotencyKey: user.id + plan.id });
 					logger.info(`Subscription plan changed for user ${user.id} to plan ${plan.id}`);
 
 					return;
@@ -180,7 +182,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					customer: userProfile.stripeCustomerId ?? undefined,
 					allow_promotion_codes: true,
 					return_url: `${this.config.url}/settings/subscription`,
-				}, {});
+				});
 
 				return {
 					redirect: {

--- a/packages/backend/src/server/api/endpoints/subscription/create.ts
+++ b/packages/backend/src/server/api/endpoints/subscription/create.ts
@@ -8,6 +8,7 @@ import { MetaService } from '@/core/MetaService.js';
 import type { Config } from '@/config.js';
 import { RoleService } from '@/core/RoleService.js';
 import { ApiError } from '../../error.js';
+import { LoggerService } from "@/core/LoggerService.js";
 
 export const meta = {
 	tags: ['subscription'],
@@ -46,6 +47,12 @@ export const meta = {
 			id: 'f1b0a9f3-9f8a-4e8c-9b4d-0d2c1b7a9c0b',
 		},
 
+		statusInconsistency: {
+			message: 'The information registered in the payment service and the information stored on the server do not match.',
+			code: 'STATUS_INCONSENT',
+			id: 'f1d204e7-276a-4277-9e7b-14f5e038c2d8',
+		},
+
 		unavailable: {
 			message: 'Subscription unavailable.',
 			code: 'UNAVAILABLE',
@@ -75,8 +82,10 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 		private subscriptionPlansRepository: SubscriptionPlansRepository,
 		private roleService: RoleService,
 		private metaService: MetaService,
+		private loggerService: LoggerService,
 	) {
 		super(meta, paramDef, async (ps, me) => {
+			const logger = this.loggerService.getLogger('subscription:create');
 			const instance = await this.metaService.fetch(true);
 			if (!(instance.enableSubscriptions)) {
 				throw new ApiError(meta.errors.unavailable);
@@ -101,6 +110,12 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 
 			const stripe = new Stripe(this.config.stripe.secretKey);
 			if (!userProfile.stripeCustomerId) {
+				const searchCustomer = await stripe.customers.search({ query: `email:"${userProfile.email}"` });
+				if (searchCustomer.data.length !== 0) {
+					logger.info(`User with email ${userProfile.email} is already registered in Stripe but not recorded in UserProfile.`);
+					throw new ApiError(meta.errors.statusInconsistency);
+				}
+
 				const makeCustomer = await stripe.customers.create({
 					email: userProfile.email,
 				});
@@ -108,6 +123,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					stripeCustomerId: makeCustomer.id,
 				});
 				userProfile = await this.userProfilesRepository.findOneByOrFail({ userId: user.id });
+				logger.info(`New Stripe customer created with ID ${makeCustomer.id} and associated with user ${user.id}`);
 			}
 
 			const subscriptionStatus = user.subscriptionStatus;
@@ -136,6 +152,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 							for (const role of roles) {
 								if (roleIds.includes(role.id)) {
 									await this.roleService.unassign(user.id, role.id);
+									logger.info(`${user.id} has been unassigned the role "${role.id}".`);
 								}
 							}
 						});
@@ -151,6 +168,7 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 					}
 
 					await stripe.subscriptionItems.update(subscriptionItem.id, { plan: plan.stripePriceId });
+					logger.info(`Subscription plan changed for user ${user.id} to plan ${plan.id}`);
 
 					return;
 				} else {


### PR DESCRIPTION
ついでにログいっぱい増やした

<!-- ℹ お読みください / README
PRありがとうございます！ PRを作成する前に、コントリビューションガイドをご確認ください:
Thank you for your PR! Before creating a PR, please check the contribution guide:
https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md
-->

## What
<!-- このPRで何をしたのか？ どう変わるのか？ -->
<!-- What did you do with this PR? How will it change things? -->
Stripeに顧客を作成するエンドポイントを実行する前に、登録しようとしているメールアドレスが既にStripeに登録されていないか問い合わせるようにした。  
これによりなぜか2回呼ばれることはなくなったはず。

## Why
<!-- なぜそうするのか？ どういう意図なのか？ 何が困っているのか？ -->
<!-- Why do you do it? What are your intentions? What is the problem? -->
最初に作成した顧客がきちんと保存されていない状態でもう1回呼ばれた場合に2つ顧客が作成されてしまう上に、何らかのり

## Additional info (optional)
<!-- テスト観点など -->
<!-- Test perspective, etc -->

## Checklist
- [ ] Read the [contribution guide](https://github.com/misskey-dev/misskey/blob/develop/CONTRIBUTING.md)
- [x] Test working in a local environment
- [ ] (If needed) Add story of storybook
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests
